### PR TITLE
Replace safeHTML with markdownify for easier content management.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,7 +22,7 @@
         </div>
         <div class="layui-col-xs12 layui-col-sm8 layui-col-md8 about_right">
             <h1>Biography</h1>
-            <h2>{{ safeHTML .Site.Params.Bio }}</h2>
+            <h2>{{ markdownify .Site.Params.Bio }}</h2>
         </div>
     </div>
 </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,6 +18,6 @@
     {{end}}
     
     <div class="layui-container">
-        <p class="copyright">{{ .Site.Params.copyright | default "&copy; All rights reserved. Powered by [Hugo](https://gohugo.io) and [Erblog](https://github.com/ertuil/erblog)." | safeHTML }}</p>
+        <p class="copyright">{{ .Site.Params.copyright | default "&copy; All rights reserved. Powered by [Hugo](https://gohugo.io) and [Erblog](https://github.com/ertuil/erblog)." | markdownify }}</p>
     </div>
 </footer>


### PR DESCRIPTION
Markdown is a superset of HTML, so you can render existing HTMLs in Markdown without changes, but you can use Markdown syntax as well. Also given the default in `layouts/partials/footer.html:21` I think this has always been the intended behaviour.