### PR TITLE
Use truncate for Summary as it is html aware

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -7,9 +7,9 @@
         	{{ if isset .Params "description" }}
 				{{ .Description }}
 			{{ else if gt (len .Summary) 150 }}
-				{{ slicestr .Summary 0 150 }}
+				{{ .Summary | truncate 150 " ..." }}
             {{else if .Summary}}
                 {{.Summary}}
-            {{end}} ... <a href="{{.RelPermalink}}"><span style="color:#01AAED">Read More</span></a>
+            {{end}} <a href="{{.RelPermalink}}"><span style="color:#01AAED">Read More</span></a>
         </h3>
     </blockquote>


### PR DESCRIPTION
I recently had the problem that a post with single quote ended up to have a summary on the index page like "Something&rsquo;s wrong and so on and so forth ..."

But as truncate is HTML in comparison to slicestr using it fixes the problem.