### PR TITLE
Do not show title twice on home-page

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>{{ .Site.Title }}{{if.Title}} - {{.Title}} {{end}}</title>
+    <title>{{ .Site.Title }}{{if and (not .IsHome) (.Title)}} - {{.Title}} {{end}}</title>
 
     
     {{if .Params.tags}}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -31,8 +31,10 @@
                 <dd><a href="/post/">Posts</a></dd>
                 <!--<dd><a href="/gallery/">Gallery</a></dd>-->
 
-                {{ range sort .Site.Menus.main }}
-                    <dd><a href="{{ .URL }}">{{ .Name }}</a></dd>
+                {{ if .Site.Menus.main }}
+                    {{ range sort .Site.Menus.main }}
+                        <dd><a href="{{ .URL }}">{{ .Name }}</a></dd>
+                    {{ end }}
                 {{ end }}
             </dl>
         </li>


### PR DESCRIPTION
In order to not show "My Blog Title - My Blog Title" on the home page check also if the current page is the home page in the title tag.

If this does not suit you, please reject.